### PR TITLE
Add dynamic configuration for tutorials

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,5 @@
 Django>=3.2.5
+PyYAML>=5.4.1
 
 # Web server
 gunicorn>=20.1.0

--- a/app/vc_tutorial/settings.py
+++ b/app/vc_tutorial/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
 import os
-
 from pathlib import Path
 
 
@@ -22,6 +21,10 @@ def parse_bool(val):
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+CONFIG_PATH = os.getenv(
+    "CONFIG_PATH",
+    "/var/www/static/config",
+)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/

--- a/app/vc_tutorial/templates/index.html
+++ b/app/vc_tutorial/templates/index.html
@@ -5,6 +5,13 @@
     <head>
     </head>
     <body>
-        <h1>List of apps and stuff goes here</h1>
+        <h1>List of available tutorials:</h1>
+        <ul>
+        {% for tutorial in tutorial_list %}
+            <li>
+                <a href="/{{tutorial}}">{{tutorial}}</a>
+            </li>
+        {% endfor %}
+        </ul>
     </body>
 </html>

--- a/app/vc_tutorial/templates/vue-app.html
+++ b/app/vc_tutorial/templates/vue-app.html
@@ -6,9 +6,15 @@
         <link type="text/css" rel="stylesheet" href="{% static 'ui/css/app.css' %}"></link>
     </head>
     <body>
-        Route name: {{ route }}
+        <!-- Load context object using Django template -->
+        <script type="text/javascript">
+            var context = JSON.parse('{{ context | safe }}');
+        </script>
+
+        <!-- Placeholder for Vue app -->
         <div id="app"></div>
 
+        <!-- Load Vue app source bundles -->
         <script type="text/javascript" src="{% static 'ui/js/chunk-vendors.js' %}"></script>
         <script type="text/javascript" src="{% static 'ui/js/app.js' %}"></script>
     </body>

--- a/app/vc_tutorial/views/main.py
+++ b/app/vc_tutorial/views/main.py
@@ -1,5 +1,20 @@
+import os
+
+from django.conf import settings
 from django.shortcuts import render
 
 
 def index(request):
-    return render(request, "index.html")
+
+    tutorial_list = []
+
+    for confpath, dirnames, files in os.walk(settings.CONFIG_PATH):
+        for appdir in dirnames:
+            current_app_path = os.path.join(settings.CONFIG_PATH, appdir)
+            for dirpath, dirnames, files in os.walk(current_app_path):
+                if not files or not files.__contains__("tutorialConfig.yaml"):
+                    print(dirpath, "empty")
+                    continue
+                tutorial_list.append(appdir)
+
+        return render(request, "index.html", context={"tutorial_list": tutorial_list})

--- a/app/vc_tutorial/views/vue_app.py
+++ b/app/vc_tutorial/views/vue_app.py
@@ -17,7 +17,7 @@ def index(request, path):
     if os.path.isdir(config_path):
         for dirpath, dirnames, files in os.walk(config_path):           
             if not files or not files.__contains__("config.yaml"):
-                raise Http404(f"No tutorial found for /{path}")
+                raise Http404(f"No configured tutorial found for /{path}")
             
             config_file_path = os.path.join(config_path, "config.yaml") 
             with open(config_file_path, 'r') as stream:

--- a/app/vc_tutorial/views/vue_app.py
+++ b/app/vc_tutorial/views/vue_app.py
@@ -1,5 +1,30 @@
+import json
+import os
+
+
+from django.conf import settings
+from django.http import Http404, HttpResponseServerError
 from django.shortcuts import render
+import yaml
 
 
 def index(request, path):
-    return render(request, "vue-app.html", {"route": path})
+    appContext = {}
+    appContext["path"] = path
+
+    config_path = os.path.join(settings.CONFIG_PATH, path)
+
+    if os.path.isdir(config_path):
+        for dirpath, dirnames, files in os.walk(config_path):           
+            if not files or not files.__contains__("config.yaml"):
+                raise Http404(f"No tutorial found for /{path}")
+            
+            config_file_path = os.path.join(config_path, "config.yaml") 
+            with open(config_file_path, 'r') as stream:
+                try:
+                    config_data = yaml.load(stream)
+                    appContext["content"] = config_data
+                except yaml.YAMLError as exc:
+                    raise HttpResponseServerError(exc)
+
+    return render(request, "vue-app.html", context={"context": json.dumps(appContext)})

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -4,11 +4,13 @@ services:
     restart: always
     image: vc-tutorial-site
     environment:
+      CONFIG_PATH: /var/www/static/config
       DJANGO_DEBUG: ${DEBUG}
       APP_SCRIPT: ${APP_SCRIPT}
       STI_SCRIPTS_PATH: ${STI_SCRIPTS_PATH}
     volumes:
       - ../app:/opt/app-root/src
+      - ./site/config:/var/www/static/config
       - ui-artifacts:/var/dev/static/ui
     ports:
       - 8000:8080

--- a/docker/site/config/tutorial_1/config.yaml
+++ b/docker/site/config/tutorial_1/config.yaml
@@ -1,0 +1,4 @@
+title: "This is a title"
+section_1:
+  paragraph_1: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+  paragraph_two: "Praesent faucibus est eu tortor ornare elementum."


### PR DESCRIPTION
Changes include:
- list of all available (with configuration) apps when hitting the root of the webapp
- dynamic loading of configuration from yaml file for configurd apps, and injection of static resource in the webpage

To create a new app, all that is required is to add a folder containing a `config.yaml` file in the defined `CONFIG_PATH` (`/var/www/static/config` by default). If the framework detects that a folder named the same as the requested path exists, and a `config.yaml` file is present it will render the Vue app. If this is not true a `404` error is raised.